### PR TITLE
Updated Shop page to show only correct items

### DIFF
--- a/artshop.server/server/Controllers/SquareController.cs
+++ b/artshop.server/server/Controllers/SquareController.cs
@@ -152,7 +152,7 @@ public class SquareController : Controller
         foreach (CatalogVariationDisplay item in displayObjects)
         {
             if (!filteredVariations.TryGetValue(item.ItemId, out CatalogVariationDisplay? value) || 
-                    item.Price.Amount >= value.Price.Amount)
+                    item.Price.Amount <= value.Price.Amount)
             {
                 filteredVariations[item.ItemId] = item;
             }

--- a/artshop.server/server/Controllers/SquareController.cs
+++ b/artshop.server/server/Controllers/SquareController.cs
@@ -141,7 +141,19 @@ public class SquareController : Controller
 
         PairImagesToCatalogDisplayObjects(displayObjects, catalogImages);
 
-        return displayObjects;
+        Dictionary<string, CatalogVariationDisplay> filteredVariations = [];
+        
+        foreach (CatalogVariationDisplay item in displayObjects)
+        {
+            if (!filteredVariations.TryGetValue(item.ItemId, out CatalogVariationDisplay? value) || 
+                    item.Price.Amount >= value.Price.Amount)
+            {
+                filteredVariations[item.ItemId] = item;
+            }
+
+        }
+
+        return filteredVariations.Values.ToList();
     }
 
     // TODO: Revise this method to filter the response to just the relevant details

--- a/artshop.server/server/Controllers/SquareController.cs
+++ b/artshop.server/server/Controllers/SquareController.cs
@@ -126,6 +126,12 @@ public class SquareController : Controller
         {
             if (item.IsItem)
             {
+                // TODO: Currently, it's assumed that items without categories are to be excluded from the web store.
+                    // It would be better to use the ecom_visibility property in Square to choose which items to in/exclude.
+                if ((item.AsItem().ItemData?.Categories?.Count() ?? 0) == 0)
+                {
+                    continue;
+                }
                 var retrievedVariations = GetDisplayVariationsFromItem(item);
                 displayObjects.AddRange(retrievedVariations);
             }


### PR DESCRIPTION
Removed duplicates from the Shop page.
Removed in-person-only items from the Shop page.

Currently, items in the shop page are displayed with their lowest price. In future, we can change this to displaying a range, if we want.
The in-person items are filtered by Category, under the assumption that in-person items have no assigned Categories, while online-eligible items have at least one. In future, we should replace this behavior by using the ecom_visibility property in Square.