### PR TITLE
Stock handling

### DIFF
--- a/artshop.client/src/pages/Cart.css
+++ b/artshop.client/src/pages/Cart.css
@@ -210,6 +210,10 @@
     transition: scale 100ms ease-in-out;
 }
 
+.disabled-qty-btn {
+    cursor: not-allowed;
+}
+
 .checkout-container {
     display: grid;
     justify-content: right;

--- a/artshop.client/src/pages/Cart.jsx
+++ b/artshop.client/src/pages/Cart.jsx
@@ -24,9 +24,15 @@ export default function Cart() {
     const [cartItemDetails, setCartItemDetails] = useState([]);
     const [isLoading, setLoading] = useState(false);
     const [cookies, setCookie, removeCookie] = useCookies(['cart']);
+    const [stockCounts, setStockCounts] = useState({});
 
     function IncrementQ(variationId) {
         let cartList = cookies.cart;
+        let currentCount = 0;
+        for (const cartItem of cartList) {
+            if (cartItem === variationId) currentCount ++;
+        }
+        if (currentCount >= stockCounts[variationId]) return;
         cartList.push(variationId);
         setCookie('cart', cartList);
     }
@@ -68,22 +74,34 @@ export default function Cart() {
         globalThis.location.href = paymentLinkSrc;
     }
 
+    async function fetchItemStockCounts() {
+        let stockCountResponse = await fetch(`/api/square/GetInventoryCount`);
+        if (!stockCountResponse.ok || stockCountResponse.errors) {
+            console.log("Unexpected error while retrieving stock counts");
+            return;
+        }
+        let stockData = await stockCountResponse.json();
+        let stockDict = {};
+        for (const stockItem of stockData) {
+            let trackedStockCount = stockDict[stockItem.catalog_object_id] ?? 0;
+            trackedStockCount += Number.parseInt(stockItem.quantity);
+            stockDict[stockItem.catalog_object_id] = trackedStockCount;
+        }
+        setStockCounts(stockDict);
+    }
+
     useEffect(() => {
         async function fetchItemDetails(cartDict) {
             let httpResults = []
             for (let [cartItemId] of Object.entries(cartDict)){
                 httpResults.push(fetch(`/api/square/GetCatalogItem/` + cartItemId));
             }
-
+            await fetchItemStockCounts();
             await Promise.all(httpResults).then(async (httpResponse) => {
                 let itemsInCart = [];
                 for (const result of httpResponse) {
-                    if (!result.ok) {
-                        console.log("Unexpected HTTP error in response from API");
-                        continue;
-                    }
-                    if (result.errors) {
-                        console.log("Unexpected Square error in response from API");
+                    if (!result.ok || result.errors) {
+                        console.log("Unexpected error while retrieving item details");
                         continue;
                     }
                     let squareItemDetails = (await result.json());
@@ -113,7 +131,7 @@ export default function Cart() {
     let grandTotal = 0;
 
     for (const cartItem of cartItemDetails) {
-        let itemName = "ERROR: Item name not found."
+        let itemName = "ERROR: Item name not found.\n"
         let itemImageSrc = "";
         let priceCents = cartItem.object.item_variation_data.price_money.amount/100;
 
@@ -125,7 +143,14 @@ export default function Cart() {
                 itemImageSrc = relatedObject.image_data.url;
             }
         }
+        itemName += ` (${cartItem.object.item_variation_data.name})`
         grandTotal += priceCents * cartItem.quantity;
+
+        let incrementBtnClass = "cart-qty-btn";
+        if (cartItem.quantity >= stockCounts[cartItem.object.id]) {
+            incrementBtnClass = "cart-qty-btn disabled-qty-btn";
+        }
+
         cartContents.push(
         <tr>
             <td className='no-indent'>
@@ -138,7 +163,7 @@ export default function Cart() {
                 <div className="quantity-selector">
                     <button onClick={() => DecrementQ(cartItem.object.id)} className="cart-qty-btn"><ChevronLeft /></button>
                     <p>{cartItem.quantity}</p>
-                    <button onClick={() => IncrementQ(cartItem.object.id)} className="cart-qty-btn"><ChevronRight /></button>
+                    <button onClick={() => IncrementQ(cartItem.object.id)} className={incrementBtnClass}><ChevronRight /></button>
                 </div>
             </td>
             <td data-label="Subtotal">${(priceCents * cartItem.quantity).toFixed(2)}</td>

--- a/artshop.client/src/pages/Home.jsx
+++ b/artshop.client/src/pages/Home.jsx
@@ -19,26 +19,44 @@ export default function Home() {
     // In this case, we only run it once, to set the state initially
         // (In case you're curious, we don't technically need an Effect for a one-time change, but it's the easiest way in this use case)
     useEffect(() => {
-        setLoading(true);
-        setShopItems(null);
+        async function fetchCatalogItems() {
+            let catalogItemsResponse = await fetch(`/api/square/ListCatalogVariationsForDisplay`);
+            if (!catalogItemsResponse.ok) {
+                console.log("Unexpected HTTP error while retrieving catalog items");
+                throw new Error("HTTP error");
+            }
+            let catalogStockResponse = await fetch(`/api/square/GetInventoryCount`);
+            if (!catalogStockResponse.ok) {
+                console.log("Unexpected HTTP error while retrieving stock counts");
+                throw new Error("HTTP error");
+            }
 
-        fetch(`/api/square/ListCatalogVariationsForDisplay`)
-            .then((resp) => {
-                if (!resp.ok) {
-                    throw new Error("HTTP error");
+            let catalogData = await catalogItemsResponse.json();
+            let stockData = await catalogStockResponse.json();
+            let stockDict = {};
+            
+            for (const stockItem of stockData) {
+                let trackedStockCount = stockDict[stockItem.catalog_object_id] ?? 0;
+                trackedStockCount += stockItem.quantity;
+                stockDict[stockItem.catalog_object_id] = trackedStockCount;
+            }
+
+            let catalogItems = []
+            for (const element of catalogData) {
+                if (catalogItems.length >= ITEM_COUNT) break;
+                if (stockDict[element.variationId] <= 0) {
+                    continue;
                 }
-                return resp.json();
-            })
-            .then((data) => {
-                let catalogItems = []
-                for (const element of data) {
-                    let shopItem = <ShopItem imgSrc={element.imageURL} title={element.itemName} priceCents={element.price.amount} itemId={element.itemId}/>
-                    catalogItems.push(shopItem);
-                    if (catalogItems.length >= ITEM_COUNT) break;
-                }
-                setShopItems(catalogItems);
-                setLoading(false);
-            })
+                let shopItem = <ShopItem imgSrc={element.imageURL} title={element.itemName} priceCents={element.price.amount} itemId={element.itemId}/>
+                catalogItems.push(shopItem);
+            }
+            setShopItems(catalogItems);
+            setLoading(false);
+        }
+
+        setLoading(true);
+        fetchCatalogItems();
+
     }, []);
 
     if (loading) {

--- a/artshop.client/src/pages/ItemPage.css
+++ b/artshop.client/src/pages/ItemPage.css
@@ -160,6 +160,11 @@
     transition: scale 100ms ease-in-out;
 }
 
+.disabled-btn{
+    cursor: not-allowed;
+    color: grey;
+}
+
 .item-description{
     text-wrap: wrap;
 }

--- a/artshop.client/src/pages/ItemPage.tsx
+++ b/artshop.client/src/pages/ItemPage.tsx
@@ -9,7 +9,8 @@ export default function ItemPage() {
 
     const [cookies, setCookie] = useCookies(['cart']);
 
-    const [quantity, setQuantity] = useState(1)
+    const [quantity, setQuantity] = useState(1);
+    const [stockCount, setStockCount] = useState(0);
     const [itemDetails, setItemDetails] = useState();
     const [itemVariationDetails, setItemVariationDetails] = useState();
     const [loading, setLoading] = useState(true);
@@ -43,6 +44,20 @@ export default function ItemPage() {
     }, [itemId]);
 
     useEffect(() => {
+        if (!variationId) return;
+        fetch(`/api/square/GetInventoryCount/` + variationId)
+            .then((resp) => {
+                if (!resp.ok) {
+                    throw new Error("HTTP error");
+                }
+                return resp.text();
+            })
+            .then((data) => {
+                setStockCount(Number.parseInt(data));
+            })
+    }, [variationId]);
+
+    useEffect(() => {
         if (itemDetails) {
             let variations = itemDetails.object.item_data.variations;
             let newSkuButtons = []
@@ -61,6 +76,7 @@ export default function ItemPage() {
 
 
     function IncrementQ() {
+        if (quantity >= stockCount) return;
         setQuantity(curQuantity => {
             return curQuantity + 1
         });
@@ -96,6 +112,12 @@ export default function ItemPage() {
             cartItems.push(variationId);
         }
         setCookie('cart', cartItems);
+        globalThis.location.href = `/shop`;
+    }
+
+    let incrementButtonClass = "qty-btn";
+    if (quantity >= stockCount) {
+        incrementButtonClass = "qty-btn disabled-btn";
     }
 
     return (
@@ -112,7 +134,7 @@ export default function ItemPage() {
                 <div className="quantity-selector">
                     <button onClick={DecrementQ} className = "qty-btn" style={{left: 0}}><ChevronLeft /></button>
                     <p>{quantity}</p>
-                    <button onClick={IncrementQ} className = "qty-btn" style={{right: 0}}><ChevronRight /></button>
+                    <button onClick={IncrementQ} className = {incrementButtonClass} style={{right: 0}}><ChevronRight /></button>
                 </div>
                 <button className = "cart-add-btn" onClick={addToCart}>Add to cart</button>
                 <div>

--- a/artshop.client/src/pages/ItemPage.tsx
+++ b/artshop.client/src/pages/ItemPage.tsx
@@ -74,6 +74,17 @@ export default function ItemPage() {
         }
     }, [variationId, itemDetails]);
 
+    useEffect(() => {
+        if (!cookies.cart) return;
+        let currentCartQuantity = 0;
+        for (const cartItem of cookies.cart) {
+            if (cartItem == variationId) {
+                currentCartQuantity++;
+            }
+        }
+        setQuantity(currentCartQuantity);
+    }, [variationId])
+
 
     function IncrementQ() {
         if (quantity >= stockCount) return;
@@ -108,10 +119,11 @@ export default function ItemPage() {
         if (cookies.cart) {
             cartItems = cookies.cart;
         }
+        let filteredCartList = cartItems.filter(cartItem => cartItem != variationId);
         for (let i = 0; i < quantity; i++) {
-            cartItems.push(variationId);
+            filteredCartList.push(variationId);
         }
-        setCookie('cart', cartItems);
+        setCookie('cart', filteredCartList);
         globalThis.location.href = `/shop`;
     }
 

--- a/artshop.client/src/pages/Shop.jsx
+++ b/artshop.client/src/pages/Shop.jsx
@@ -2,51 +2,56 @@ import { useState, useEffect } from 'react';
 import ShopItem from "../ShopItem";
 import './Shop.css'
 
-// Detailed comments are included for this file for future reference.
 export default function Home() {
-    // Set up the state variables we'll be using.
-    // In React, State is used to store any information; in this case, mainly the list of catalog items we want to display.
     const [shopItems, setShopItems] = useState();
     const [loading, setLoading] = useState(true);
 
-    // An Effect is a function that's run occasionally to update the State if something might have changed it.
-    // In this case, we only run it once, to set the state initially
-        // (In case you're curious, we don't technically need an Effect for a one-time change, but it's the easiest way in this use case)
     useEffect(() => {
-        // Before we've done anything, set Loading to true.
-        // We check for this at the end of the Effect to determine whether to send a temporary loading page or not.
-        setLoading(true);
-        setShopItems(null);
 
-        // Here, we use the fetch() function to call the API, parsing the response into JSON.
-        fetch(`/api/square/ListCatalogVariationsForDisplay`)
-            // Because this returns a Promise, we use `.then()` to run code that uses the output of fetch -- if we don't, we'll get an unusable object of type Promise.
-            .then((resp) => {
-                if (!resp.ok) {
-                    throw new Error("HTTP error");
+        async function fetchCatalogItems() {
+            let catalogItemsResponse = await fetch(`/api/square/ListCatalogVariationsForDisplay`);
+            if (!catalogItemsResponse.ok) {
+                console.log("Unexpected HTTP error while retrieving catalog items");
+                throw new Error("HTTP error");
+            }
+            let catalogStockResponse = await fetch(`/api/square/GetInventoryCount`);
+            if (!catalogStockResponse.ok) {
+                console.log("Unexpected HTTP error while retrieving stock counts");
+                throw new Error("HTTP error");
+            }
+
+            let catalogData = await catalogItemsResponse.json();
+            let stockData = await catalogStockResponse.json();
+            let stockDict = {};
+            
+            for (const stockItem of stockData) {
+                let trackedStockCount = stockDict[stockItem.catalog_object_id] ?? 0;
+                trackedStockCount += stockItem.quantity;
+                stockDict[stockItem.catalog_object_id] = trackedStockCount;
+            }
+
+            let catalogItems = []
+            for (const element of catalogData) {
+                if (stockDict[element.variationId] <= 0) {
+                    continue;
                 }
-                return resp.json();
-            })
-            // We can use .then() on the output of the prior .then() to handle the output after parsing succeeds
-            .then((data) => {
-                let catalogItems = []
-                for (const element of data) {
-                    let shopItem = <ShopItem imgSrc={element.imageURL} title={element.itemName} priceCents={element.price.amount} itemId={element.itemId}/>
-                    catalogItems.push(shopItem);
-                }
-                setShopItems(catalogItems);
-                setLoading(false);
-            })
+                let shopItem = <ShopItem imgSrc={element.imageURL} title={element.itemName} priceCents={element.price.amount} itemId={element.itemId}/>
+                catalogItems.push(shopItem);
+            }
+            setShopItems(catalogItems);
+            setLoading(false);
+        }
+
+        setLoading(true);
+        fetchCatalogItems();
     }, []);
 
-    // If the internal state is still loading, show a temporary loading message to make the page feel more responsive
     if (loading) {
         return(
             <div>Loading...</div>
         )
     }
 
-    // (otherwise,) return the page, now that we have access to the data we need.
     return (
         <div className="shop">
             <div className="filter-panel">

--- a/artshop.server/server/Controllers/SquareController.cs
+++ b/artshop.server/server/Controllers/SquareController.cs
@@ -228,7 +228,7 @@ public class SquareController : Controller
     /// Retrieve the counts of all item stock in the inventory
     /// </summary>
     /// <returns>The counts of item stocks, as returned by Square</returns>
-    [HttpGet("GetInventoryCounts")]
+    [HttpGet("GetInventoryCount")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<List<InventoryCount>> GetInventoryCounts()
     {
@@ -241,5 +241,33 @@ public class SquareController : Controller
             inventoryCounts.Add(inventoryCount);
         }
         return inventoryCounts;
+    }
+
+    /// <summary>
+    /// Retrieve the inventory count for a single item across all locations
+    /// </summary>
+    /// <param name="id">The ID of the item to pull inventory counts for</param>
+    /// <returns>The number of items in stock</returns>
+    [HttpGet("GetInventoryCount/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetItemInventoryCount(string id)
+    {
+        Pager<InventoryCount> result = await client.Inventory.GetAsync(
+            new GetInventoryRequest{
+                CatalogObjectId = id
+            }
+        );
+
+        int itemCount = 0;
+        bool isItemFound = false;
+        await foreach (InventoryCount inventoryCount in result)
+        {
+            isItemFound = true;
+            itemCount += int.Parse(inventoryCount.Quantity ?? "0", 0);
+        }
+        if (!isItemFound) return NotFound($"No item matching id `{id} was found in any location.");
+        return Ok(itemCount);
+
     }
 }

--- a/artshop.server/server/Controllers/SquareController.cs
+++ b/artshop.server/server/Controllers/SquareController.cs
@@ -5,6 +5,7 @@ using Square.Checkout.PaymentLinks;
 using Square.Catalog;
 using Square.Core;
 using Square.Catalog.Object;
+using Square.Inventory;
 
 using artshop.Server.Models;
 
@@ -221,5 +222,24 @@ public class SquareController : Controller
         if (linkResponse.PaymentLink.Url == null) throw new SquareException("The payment link was created, but it did not generate a valid URL");
         
         return linkResponse.PaymentLink.Url;
+    }
+
+    /// <summary>
+    /// Retrieve the counts of all item stock in the inventory
+    /// </summary>
+    /// <returns>The counts of item stocks, as returned by Square</returns>
+    [HttpGet("GetInventoryCounts")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<List<InventoryCount>> GetInventoryCounts()
+    {
+        Pager<InventoryCount> getCountsResponse = await client.Inventory.BatchGetCountsAsync(
+            new BatchGetInventoryCountsRequest()
+        );
+        List<InventoryCount> inventoryCounts = [];
+        await foreach (InventoryCount inventoryCount in getCountsResponse)
+        {
+            inventoryCounts.Add(inventoryCount);
+        }
+        return inventoryCounts;
     }
 }


### PR DESCRIPTION
Added routes to check stock counts
Added checks on Shop page to prevent the user from adding more items than we have stock.
Added checks on Checkout page to prevent the user from adding more items than we have stock.
Made minor style changes to make the user flow more intuitive.

Note that there's currently no signifier to tell the user that the item page manipulates their existing cart (as opposed to adding more items to the cart).